### PR TITLE
switch to another reed-solomon lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,8 +515,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.10.1"
-source = "git+https://github.com/arkpar/scale-info.git#c1ab45ea6625010dd93fa5c1a4cd44c3b7531c99"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7d66a1128282b7ef025a8ead62a4a9fcf017382ec53b8ffbf4d7bf77bd3c60"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -527,7 +528,8 @@ dependencies = [
 [[package]]
 name = "scale-info-derive"
 version = "2.10.0"
-source = "git+https://github.com/arkpar/scale-info.git#c1ab45ea6625010dd93fa5c1a4cd44c3b7531c99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf2c68b89cafb3b8d918dd07b42be0da66ff202cf1155c5739a4e0c1ea0dc19"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
+name = "bytemuck"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,12 +97,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "ciborium"
@@ -218,18 +218,15 @@ dependencies = [
  "criterion",
  "parity-scale-codec",
  "quickcheck",
- "reed-solomon-novelpoly",
+ "reed-solomon-simd",
  "thiserror",
 ]
 
 [[package]]
-name = "fs-err"
-version = "2.11.0"
+name = "fixedbitset"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
-dependencies = [
- "autocfg",
-]
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "getrandom"
@@ -301,15 +298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,16 +323,6 @@ name = "libc"
 version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
-
-[[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -407,31 +385,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
 ]
 
 [[package]]
@@ -500,23 +453,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "readme-rustdocifier"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
 
 [[package]]
-name = "reed-solomon-novelpoly"
-version = "1.0.2"
-source = "git+https://github.com/paritytech/reed-solomon-novelpoly.git#e6e641e8b97027e691a7d28cc69a23ed2f3a097b"
+name = "reed-solomon-simd"
+version = "2.1.0"
+source = "git+https://github.com/ordian/reed-solomon-simd?branch=simd-feature#52d42754a13508581cdc48dc7ea6321cfdf918db"
 dependencies = [
- "derive_more",
- "fs-err",
- "static_init",
- "thiserror",
+ "bytemuck",
+ "fixedbitset",
+ "once_cell",
+ "readme-rustdocifier",
 ]
 
 [[package]]
@@ -586,12 +536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,40 +564,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
-
-[[package]]
-name = "static_init"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
-dependencies = [
- "bitflags",
- "cfg_aliases",
- "libc",
- "parking_lot",
- "parking_lot_core",
- "static_init_macro",
- "winapi",
-]
-
-[[package]]
-name = "static_init_macro"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a2595fc3aa78f2d0e45dd425b22282dd863273761cc77780914b2cf3003acf"
-dependencies = [
- "cfg_aliases",
- "memchr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ scale-info = { git = "https://github.com/arkpar/scale-info.git" }
 [dependencies]
 blake2b_simd = { version = "1", default-features = false }
 bounded-collections = { version = "0.1.9", default-features = false }
-novelpoly = { package = "reed-solomon-novelpoly", git = "https://github.com/paritytech/reed-solomon-novelpoly.git", default-features = false }
+reed-solomon = { package = "reed-solomon-simd", git = "https://github.com/ordian/reed-solomon-simd", branch = "simd-feature" }
 scale = { package = "parity-scale-codec", version = "3.6.9", default-features = false,  features = ["derive"] }
 thiserror = { version = "1.0.56", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 
-[patch.crates-io]
-scale-info = { git = "https://github.com/arkpar/scale-info.git" }
-
 [dependencies]
 blake2b_simd = { version = "1", default-features = false }
 bounded-collections = { version = "0.1.9", default-features = false }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
 	NotEnoughChunks,
 	#[error("Chunks are not uniform, mismatch in length or are zero sized")]
 	NonUniformChunks,
-	#[error("Uneven length is not valid for field GF(2^16)")]
+	#[error("Unaligned chunk length")]
 	UnalignedChunk,
 	#[error("Chunk is out of bounds: {chunk_index} not included in 0..{n_chunks}")]
 	ChunkIndexOutOfBounds { chunk_index: u16, n_chunks: u16 },
@@ -22,10 +22,8 @@ pub enum Error {
 	InvalidChunkProof,
 	#[error("The proof is too large")]
 	TooLargeProof,
-	#[error("An unknown error has appeared when reconstructing erasure code chunks")]
-	Unknown(reed_solomon::Error),
-	#[error("An unknown error has appeared when deriving code parameters from validator count")]
-	UnknownCodeParam,
+	#[error("An unknown error has appeared when (re)constructing erasure code chunks")]
+	Unknown,
 }
 
 impl From<reed_solomon::Error> for Error {
@@ -38,7 +36,7 @@ impl From<reed_solomon::Error> for Error {
 			TooManyOriginalShards { .. } => Self::TooManyTotalChunks,
 			TooFewOriginalShards { .. } => Self::NotEnoughTotalChunks,
 			DifferentShardSize { .. } => Self::NonUniformChunks,
-			err => Self::Unknown(err),
+			_ => Self::Unknown,
 		}
 	}
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 use thiserror::Error;
 
 /// Errors in erasure coding.
-#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Error)]
+#[non_exhaustive]
 pub enum Error {
 	#[error("There are too many chunks in total")]
 	TooManyTotalChunks,
@@ -13,7 +13,7 @@ pub enum Error {
 	#[error("Chunks are not uniform, mismatch in length or are zero sized")]
 	NonUniformChunks,
 	#[error("Uneven length is not valid for field GF(2^16)")]
-	UnevenLength,
+	UnalignedChunk,
 	#[error("Chunk is out of bounds: {chunk_index} not included in 0..{n_chunks}")]
 	ChunkIndexOutOfBounds { chunk_index: u16, n_chunks: u16 },
 	#[error("Reconstructed payload invalid")]
@@ -23,21 +23,22 @@ pub enum Error {
 	#[error("The proof is too large")]
 	TooLargeProof,
 	#[error("An unknown error has appeared when reconstructing erasure code chunks")]
-	UnknownReconstruction,
+	Unknown(reed_solomon::Error),
 	#[error("An unknown error has appeared when deriving code parameters from validator count")]
 	UnknownCodeParam,
 }
 
-impl From<novelpoly::Error> for Error {
-	fn from(error: novelpoly::Error) -> Self {
+impl From<reed_solomon::Error> for Error {
+	fn from(error: reed_solomon::Error) -> Self {
+		use reed_solomon::Error::*;
+
 		match error {
-			novelpoly::Error::NeedMoreShards { .. } => Self::NotEnoughChunks,
-			novelpoly::Error::ParamterMustBePowerOf2 { .. } => Self::UnevenLength,
-			novelpoly::Error::WantedShardCountTooHigh(_) => Self::TooManyTotalChunks,
-			novelpoly::Error::WantedShardCountTooLow(_) => Self::NotEnoughTotalChunks,
-			novelpoly::Error::PayloadSizeIsZero { .. } => Self::BadPayload,
-			novelpoly::Error::InconsistentShardLengths { .. } => Self::NonUniformChunks,
-			_ => Self::UnknownReconstruction,
+			NotEnoughShards { .. } => Self::NotEnoughChunks,
+			InvalidShardSize { .. } => Self::UnalignedChunk,
+			TooManyOriginalShards { .. } => Self::TooManyTotalChunks,
+			TooFewOriginalShards { .. } => Self::NotEnoughTotalChunks,
+			DifferentShardSize { .. } => Self::NonUniformChunks,
+			err => Self::Unknown(err),
 		}
 	}
 }


### PR DESCRIPTION
```
     Running benches/all.rs (target/release/deps/all-b834030c3ce351b3)
construct/131072        time:   [842.23 µs 842.50 µs 842.89 µs]
                        thrpt:  [148.30 MiB/s 148.37 MiB/s 148.42 MiB/s]
                 change:
                        time:   [-66.954% -66.723% -66.485%] (p = 0.00 < 0.05)
                        thrpt:  [+198.38% +200.51% +202.61%]
                        Performance has improved.
Found 1 outliers among 15 measurements (6.67%)
  1 (6.67%) high mild
construct/1048576       time:   [4.4437 ms 4.4488 ms 4.4547 ms]
                        thrpt:  [224.48 MiB/s 224.78 MiB/s 225.04 MiB/s]
                 change:
                        time:   [-76.801% -76.664% -76.477%] (p = 0.00 < 0.05)
                        thrpt:  [+325.12% +328.53% +331.06%]
                        Performance has improved.
Found 3 outliers among 15 measurements (20.00%)
  1 (6.67%) low mild
  2 (13.33%) high severe
construct/5242880       time:   [20.996 ms 21.056 ms 21.136 ms]
                        thrpt:  [236.56 MiB/s 237.46 MiB/s 238.14 MiB/s]
                 change:
                        time:   [-78.069% -78.024% -77.968%] (p = 0.00 < 0.05)
                        thrpt:  [+353.90% +355.04% +355.98%]
                        Performance has improved.
Found 1 outliers among 15 measurements (6.67%)
  1 (6.67%) high severe

reconstruct_regular/131072
                        time:   [953.66 µs 957.93 µs 962.76 µs]
                        thrpt:  [129.84 MiB/s 130.49 MiB/s 131.07 MiB/s]
                 change:
                        time:   [-80.863% -80.733% -80.596%] (p = 0.00 < 0.05)
                        thrpt:  [+415.36% +419.03% +422.55%]
                        Performance has improved.
Found 1 outliers among 15 measurements (6.67%)
  1 (6.67%) high mild
reconstruct_regular/1048576
                        time:   [4.1613 ms 4.1664 ms 4.1704 ms]
                        thrpt:  [239.78 MiB/s 240.02 MiB/s 240.31 MiB/s]
                 change:
                        time:   [-88.210% -88.155% -88.098%] (p = 0.00 < 0.05)
                        thrpt:  [+740.21% +744.27% +748.16%]
                        Performance has improved.
Found 1 outliers among 15 measurements (6.67%)
  1 (6.67%) high severe
reconstruct_regular/5242880
                        time:   [19.036 ms 19.046 ms 19.062 ms]
                        thrpt:  [262.30 MiB/s 262.53 MiB/s 262.65 MiB/s]
                 change:
                        time:   [-89.085% -89.066% -89.046%] (p = 0.00 < 0.05)
                        thrpt:  [+812.90% +814.59% +816.15%]
                        Performance has improved.
Found 1 outliers among 15 measurements (6.67%)
  1 (6.67%) high mild

reconstruct_systematic/131072
                        time:   [342.65 µs 347.10 µs 352.59 µs]
                        thrpt:  [354.52 MiB/s 360.13 MiB/s 364.81 MiB/s]
                 change:
                        time:   [+15.554% +17.261% +19.143%] (p = 0.00 < 0.05)
                        thrpt:  [-16.067% -14.720% -13.461%]
                        Performance has regressed.
reconstruct_systematic/1048576
                        time:   [2.3023 ms 2.3106 ms 2.3192 ms]
                        thrpt:  [431.18 MiB/s 432.79 MiB/s 434.35 MiB/s]
                 change:
                        time:   [+1.8130% +2.2025% +2.5461%] (p = 0.00 < 0.05)
                        thrpt:  [-2.4829% -2.1550% -1.7807%]
                        Performance has regressed.
reconstruct_systematic/5242880
                        time:   [11.121 ms 11.135 ms 11.166 ms]
                        thrpt:  [447.79 MiB/s 449.02 MiB/s 449.61 MiB/s]
                 change:
                        time:   [-4.5581% -4.0175% -3.3403%] (p = 0.00 < 0.05)
                        thrpt:  [+3.4557% +4.1856% +4.7758%]
                        Performance has improved.
Found 2 outliers among 15 measurements (13.33%)
  2 (13.33%) high severe

merklize/131072         time:   [806.52 µs 808.30 µs 809.89 µs]
                        thrpt:  [154.34 MiB/s 154.65 MiB/s 154.99 MiB/s]
                 change:
                        time:   [+0.2295% +0.5174% +0.7850%] (p = 0.00 < 0.05)
                        thrpt:  [-0.7789% -0.5147% -0.2289%]
                        Change within noise threshold.
merklize/1048576        time:   [3.5039 ms 3.5342 ms 3.5725 ms]
                        thrpt:  [279.92 MiB/s 282.95 MiB/s 285.39 MiB/s]
                 change:
                        time:   [-20.231% -19.868% -19.383%] (p = 0.00 < 0.05)
                        thrpt:  [+24.043% +24.795% +25.362%]
                        Performance has improved.
Found 2 outliers among 15 measurements (13.33%)
  1 (6.67%) high mild
  1 (6.67%) high severe
merklize/5242880        time:   [16.264 ms 16.337 ms 16.443 ms]
                        thrpt:  [304.08 MiB/s 306.05 MiB/s 307.43 MiB/s]
                 change:
                        time:   [-25.798% -25.224% -24.621%] (p = 0.00 < 0.05)
                        thrpt:  [+32.662% +33.733% +34.768%]
                        Performance has improved.
```