### PR TITLE
Subshard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "criterion",
  "parity-scale-codec",
  "quickcheck",
+ "rand",
  "reed-solomon-simd",
  "thiserror",
 ]
@@ -388,6 +389,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +447,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
  "rand_core",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,27 +36,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2b_simd"
@@ -127,24 +116,28 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
- "bitflags",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "constant_time_eq"
@@ -154,19 +147,19 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "regex",
  "serde",
@@ -248,24 +241,15 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -280,22 +264,23 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -312,12 +297,6 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -357,12 +336,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parity-scale-codec"
@@ -610,12 +583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,7 +624,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -668,7 +635,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap",
  "toml_datetime",
  "winnow",
 ]
@@ -725,6 +692,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ panic = "abort"
 opt-level = 1
 
 [dev-dependencies]
-criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support"] }
+criterion = { version = "0.5.1", default-features = false, features = ["cargo_bench_support"] }
 quickcheck = { version = "1.0.3", default-features = false }
 rand = { version = "0.8.4", features = [ "small_rng"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ opt-level = 1
 [dev-dependencies]
 criterion = { version = "0.4.0", default-features = false, features = ["cargo_bench_support"] }
 quickcheck = { version = "1.0.3", default-features = false }
+rand = { version = "0.8.4", features = [ "small_rng"] }
 
 [[bench]]
 name = "all"

--- a/benches/all.rs
+++ b/benches/all.rs
@@ -86,8 +86,13 @@ fn bench_all(c: &mut Criterion) {
 			group.throughput(Throughput::Bytes(pov.len() as u64));
 			group.bench_with_input(BenchmarkId::from_parameter(param), &n_chunks, |b, &n| {
 				b.iter(|| {
-					let _pov: Vec<u8> =
-						reconstruct_from_systematic(n, chunks.clone(), pov.len()).unwrap();
+					let _pov: Vec<u8> = reconstruct_from_systematic(
+						n,
+						chunks.len(),
+						&mut chunks.iter().map(Vec::as_slice),
+						pov.len(),
+					)
+					.unwrap();
 				});
 			});
 		}

--- a/fuzz/fuzz_targets/round_trip.rs
+++ b/fuzz/fuzz_targets/round_trip.rs
@@ -16,7 +16,8 @@ fuzz_target!(|data: (Vec<u8>, u16)| {
 	let threshold = systematic_recovery_threshold(n_chunks).unwrap();
 	let reconstructed_systematic: Vec<u8> = reconstruct_from_systematic(
 		n_chunks,
-		chunks.iter().cloned().take(threshold as usize).collect(),
+		chunks.len(),
+		&mut chunks.iter().map(Vec::as_slice),
 		data.len(),
 	)
 	.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,10 @@ pub fn reconstruct_from_systematic<'a>(
 	let mut shard_len = 0;
 	let mut nb = 0;
 	while let Some(chunk) = systematic_chunks.next() {
+		nb += 1;
 		if shard_len == 0 {
 			shard_len = chunk.len();
-			if shard_len % SHARD_ALIGNMENT != 0 {
+			if shard_len % SHARD_ALIGNMENT != 0 && nb != k {
 				return Err(Error::UnalignedChunk);
 			}
 
@@ -104,7 +105,6 @@ pub fn reconstruct_from_systematic<'a>(
 		}
 
 		bytes.extend_from_slice(&chunk);
-		nb += 1;
 		if nb == k {
 			break;
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ pub fn reconstruct_from_systematic<'a>(
 	let mut bytes: Vec<u8> = Vec::with_capacity(0);
 	let mut shard_len = 0;
 	let mut nb = 0;
-	while let Some(chunk) = systematic_chunks.next() {
+	for chunk in systematic_chunks.by_ref() {
 		nb += 1;
 		if shard_len == 0 {
 			shard_len = chunk.len();
@@ -104,7 +104,7 @@ pub fn reconstruct_from_systematic<'a>(
 			return Err(Error::NonUniformChunks)
 		}
 
-		bytes.extend_from_slice(&chunk);
+		bytes.extend_from_slice(chunk);
 		if nb == k {
 			break;
 		}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,34 +73,41 @@ pub fn systematic_recovery_threshold(n_chunks: u16) -> Result<u16, Error> {
 /// Due to the internals of the erasure coding algorithm, the output might be
 /// larger than the original data and padded with zeroes; passing `data_len`
 /// allows to truncate the output to the original data size.
-pub fn reconstruct_from_systematic(
+pub fn reconstruct_from_systematic<'a>(
 	n_chunks: u16,
-	systematic_chunks: Vec<Vec<u8>>,
+	systematic_len: usize,
+	systematic_chunks: &'a mut impl Iterator<Item = &'a [u8]>,
 	data_len: usize,
 ) -> Result<Vec<u8>, Error> {
 	let k = systematic_recovery_threshold(n_chunks)? as usize;
-	let Some(first_shard) = systematic_chunks.first() else {
-		return Err(Error::NotEnoughChunks);
-	};
-	if k == 1 {
-		return Ok(first_shard[..data_len].to_vec());
-	}
-	if systematic_chunks.len() < k {
+	if systematic_len < k {
 		return Err(Error::NotEnoughChunks);
 	}
-	let shard_len = first_shard.len();
-	if shard_len % SHARD_ALIGNMENT != 0 {
-		return Err(Error::UnalignedChunk);
-	}
-	for shard_data in systematic_chunks.iter().take(k) {
-		if shard_data.len() != shard_len {
+	let mut bytes: Vec<u8> = Vec::with_capacity(0);
+	let mut shard_len = 0;
+	let mut nb = 0;
+	while let Some(chunk) = systematic_chunks.next() {
+		if shard_len == 0 {
+			shard_len = chunk.len();
+			if shard_len % SHARD_ALIGNMENT != 0 {
+				return Err(Error::UnalignedChunk);
+			}
+
+			if k == 1 {
+				return Ok(chunk[..data_len].to_vec());
+			}
+			bytes = Vec::with_capacity(shard_len * k);
+		}
+
+		if chunk.len() != shard_len {
 			return Err(Error::NonUniformChunks)
 		}
-	}
 
-	let mut bytes: Vec<u8> = Vec::with_capacity(shard_len * k);
-	for chunk in systematic_chunks.into_iter().take(k) {
 		bytes.extend_from_slice(&chunk);
+		nb += 1;
+		if nb == k {
+			break;
+		}
 	}
 	bytes.resize(data_len, 0);
 
@@ -252,7 +259,8 @@ mod tests {
 			let chunks = construct_chunks(n_chunks, &available_data.0).unwrap();
 			let reconstructed: Vec<u8> = reconstruct_from_systematic(
 				n_chunks,
-				chunks.into_iter().take(threshold as usize).collect(),
+				chunks.len(),
+				&mut chunks.iter().take(threshold as usize).map(Vec::as_slice),
 				data_len,
 			)
 			.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod error;
 mod merklize;
+mod subshard;
 
 pub use self::{
 	error::Error,
@@ -12,6 +13,7 @@ pub use self::{
 
 use scale::{Decode, Encode};
 use std::ops::AddAssign;
+pub use subshard::*;
 
 pub const MAX_CHUNKS: u16 = 16384;
 

--- a/src/merklize.rs
+++ b/src/merklize.rs
@@ -47,6 +47,13 @@ impl From<InnerHash> for Hash {
 #[derive(PartialEq, Eq, Clone, Debug, Encode, Decode)]
 pub struct Proof(BoundedVec<Hash, ConstU32<MAX_MERKLE_PROOF_DEPTH>>);
 
+impl Proof {
+	/// Approximate allocated size for proof.
+	pub fn alloc_mem(&self) -> usize {
+		self.0.len() * std::mem::size_of::<Hash>()
+	}
+}
+
 impl TryFrom<MerklePath> for Proof {
 	type Error = Error;
 

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -182,6 +182,7 @@ impl SubShardDecoder {
 	{
 		let mut ori = vec![Vec::new(); TOTAL_SHARDS];
 		let mut segments = BTreeSet::new();
+		let mut segments2 = BTreeMap::<u8, usize>::new();
 		let mut nb_decode = 0;
 
 		// TODO processed and run_segments could be skiped if we are sure to get
@@ -190,6 +191,144 @@ impl SubShardDecoder {
 		for (segment, chunk_index, chunk) in subshards {
 			ori[chunk_index.0 as usize].push((segment, chunk));
 			segments.insert(segment);
+			*segments2.entry(segment).or_default() += 1;
+		}
+
+		// make batches of segments
+		let mut segment_batches = Vec::new();
+
+		let mut processed_segments2 = BTreeSet::new();
+		let mut nb_segments = 0;
+		for (segment, c) in segments2.iter() {
+			if *c >= N_SHARDS {
+				nb_segments += 1;
+			} else {
+				processed_segments2.insert(*segment);
+			}
+		}
+		while nb_segments > 0 {
+			// count all segments written, and stop at first segment having enough.
+			let mut run_segments = BTreeMap::new();
+			let mut ok = false;
+			for (_chunk_ix, chunks) in ori.iter().enumerate() {
+				for (segment_i, _chunk) in chunks {
+					if !processed_segments2.contains(segment_i) {
+						if run_segments.is_empty() {
+							if !processed_segments2.contains(segment_i) {
+								run_segments.insert(*segment_i, 1);
+							}
+						} else {
+							if let Some(c) = run_segments.get_mut(&segment_i) {
+								*c += 1;
+								if *c == N_SHARDS {
+									ok = true;
+								}
+							}
+						}
+					}
+				}
+				if ok {
+					break;
+				}
+			}
+			if !ok {
+				if run_segments.is_empty() {
+					// should not happen
+					break;
+				}
+				for (seg, _count) in run_segments.into_iter() {
+					processed_segments2.insert(seg);
+				}
+				continue;
+			}
+			// TODO max size 16, rather [;16] lookup?
+			let mut segment_batch = BTreeSet::new();
+			for (seg, count) in run_segments.into_iter() {
+				if count == N_SHARDS {
+					processed_segments2.insert(seg);
+					segment_batch.insert(seg);
+					if segment_batch.len() == 16 {
+						segment_batches.push(segment_batch);
+						segment_batch = Default::default();
+					}
+				}
+			}
+			if !segment_batch.is_empty() {
+				nb_segments -= segment_batch.len();
+				segment_batches.push(segment_batch);
+			}
+		}
+
+		for chunks in ori.iter_mut() {
+			chunks.sort_by_key(|c| c.0);
+		}
+
+		let mut result2 = Vec::new();
+		// Note that sometime byte could stay set to non zero value, but it does not matter.
+		let mut shard_buff = [0u8; BATCH_SHARD_SIZE];
+		for segments in segment_batches {
+			let mut nb_chunk = 0;
+			let mut ori_map: std::collections::BTreeMap<usize, &[u8]> = Default::default();
+			for (chunk_ix, chunks) in ori.iter().enumerate() {
+				if chunks.is_empty() {
+					continue;
+				}
+				let mut nb = 0;
+				let shard = if chunk_ix < N_SHARDS {
+					let s = &self.shards_ori[chunk_ix] as *const _ as *mut [u8; BATCH_SHARD_SIZE];
+					// each shard are only accessed a single time here.
+					unsafe { s.as_mut().expect("non null") }
+				} else {
+					&mut shard_buff
+				};
+				for (segment_i, chunk) in chunks {
+					if segments.contains(segment_i) {
+						let shard_i_s = nb * SUBSHARD_SIZE / SHARD_MIN_SIZE;
+						let shard_i_r = nb * SUBSHARD_SIZE % SHARD_MIN_SIZE;
+						let mut shard_i = shard_i_s * SHARD_MIN_SIZE + shard_i_r / POINT_SIZE;
+						for point_i in 0..SUBSHARD_POINTS {
+							shard[shard_i] = chunk[point_i * POINT_SIZE];
+							shard[shard_i + POINT_BYTE_SPACING] = chunk[(point_i * POINT_SIZE) + 1];
+							shard_i += 1;
+							if shard_i % POINT_BYTE_SPACING == 0 {
+								shard_i += POINT_BYTE_SPACING;
+							}
+						}
+						nb += 1;
+					}
+				}
+				debug_assert!(nb == 0 || nb == segments.len());
+				if nb > 0 {
+					if chunk_ix < N_SHARDS {
+						self.decoder.add_original_shard(chunk_ix, self.shards_ori[chunk_ix])?;
+						ori_map.insert(chunk_ix, &self.shards_ori[chunk_ix][..]);
+					} else {
+						self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, shard_buff)?;
+					}
+					nb_chunk += 1;
+					if nb_chunk == N_SHARDS {
+						break;
+					}
+				}
+			}
+			debug_assert!(nb_chunk == N_SHARDS);
+			let ori_ret = self.decoder.decode()?;
+			// TODO modify deps to also access original data and avoid self.ori_shards buffer.
+			// Also to avoid instantiating ori_map container.
+			for (i, o) in ori_ret.restored_original_iter() {
+				ori_map.insert(i, o);
+			}
+			debug_assert_eq!(ori_map.len(), N_SHARDS);
+			for (i, segment) in segments.iter().enumerate()  {
+				let chunk_start = i * SEGMENT_SIZE_ALIGNED;
+				let original = ori_chunk_to_data(&ori_map, chunk_start, Some(SEGMENT_SIZE))
+					.expect("number of segments checked");
+				result2.push((
+					*segment as u8,
+					Segment { data: Box::new(original), index: *segment as u32 },
+				));
+			}
+
 		}
 
 		let mut result = Vec::new();
@@ -210,6 +349,10 @@ impl SubShardDecoder {
 			for (chunk_ix, chunks) in ori.iter().enumerate() {
 				let mut added = false;
 				{
+					if chunks.is_empty() {
+						continue;
+					}
+
 					let shard = if chunk_ix < N_SHARDS {
 						let s =
 							&self.shards_ori[chunk_ix] as *const _ as *mut [u8; BATCH_SHARD_SIZE];
@@ -218,9 +361,6 @@ impl SubShardDecoder {
 					} else {
 						&mut shard_buff
 					};
-					if chunks.is_empty() {
-						continue;
-					}
 					for (segment_i, chunk) in chunks {
 						let segment_i = *segment_i as usize;
 						if nb_chunk == 0 {
@@ -295,6 +435,7 @@ impl SubShardDecoder {
 				processed_segments.insert(segment);
 			}
 		}
+		assert_eq!(result, result2); 
 		Ok((result, nb_decode))
 	}
 }

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -227,7 +227,7 @@ impl SubShardDecoder {
 			// count all segments written, and stop at first segment having enough.
 			let mut run_segments = BTreeMap::new();
 			let mut ok = false;
-			for (_chunk_ix, chunks) in ori.iter().enumerate() {
+			for chunks in ori.iter() {
 				let first = run_segments.is_empty();
 				for (segment_i, _chunk) in chunks {
 					if !processed_segments.contains(segment_i) {
@@ -235,12 +235,10 @@ impl SubShardDecoder {
 							if !processed_segments.contains(segment_i) {
 								run_segments.insert(*segment_i, 1);
 							}
-						} else {
-							if let Some(c) = run_segments.get_mut(&segment_i) {
-								*c += 1;
-								if *c == N_SHARDS {
-									ok = true;
-								}
+						} else if let Some(c) = run_segments.get_mut(segment_i) {
+							*c += 1;
+							if *c == N_SHARDS {
+								ok = true;
 							}
 						}
 					}
@@ -357,10 +355,8 @@ impl SubShardDecoder {
 				let chunk_start = i * SEGMENT_SIZE_ALIGNED;
 				let original = ori_chunk_to_data(&ori_map, chunk_start, Some(SEGMENT_SIZE))
 					.expect("number of segments checked");
-				result2.push((
-					*segment as u8,
-					Segment { data: Box::new(original), index: *segment as u32 },
-				));
+				result2
+					.push((*segment, Segment { data: Box::new(original), index: *segment as u32 }));
 			}
 		}
 

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -193,7 +193,6 @@ impl SubShardDecoder {
 
 		// TODO processed and run_segments could be skiped if we are sure to get
 		// correct number of chunks all for the same given chunk ix and segments.
-		let mut processed_segments = BTreeSet::new();
 		for (segment, chunk_index, chunk) in subshards {
 			ori[chunk_index.0 as usize].push((segment, chunk));
 			segments.insert(segment);
@@ -217,9 +216,10 @@ impl SubShardDecoder {
 			let mut run_segments = BTreeMap::new();
 			let mut ok = false;
 			for (_chunk_ix, chunks) in ori.iter().enumerate() {
+				let first = run_segments.is_empty();
 				for (segment_i, _chunk) in chunks {
 					if !processed_segments2.contains(segment_i) {
-						if run_segments.is_empty() {
+						if first {
 							if !processed_segments2.contains(segment_i) {
 								run_segments.insert(*segment_i, 1);
 							}
@@ -331,6 +331,7 @@ impl SubShardDecoder {
 			}
 			debug_assert!(nb_chunk == N_SHARDS);
 			let ori_ret = self.decoder.decode()?;
+			nb_decode += 1;
 			// TODO modify deps to also access original data and avoid self.ori_shards buffer.
 			// Also to avoid instantiating ori_map container.
 			for (i, o) in ori_ret.restored_original_iter() {
@@ -349,113 +350,7 @@ impl SubShardDecoder {
 
 		}
 
-		let mut result = Vec::new();
-
-		self.decoder.reset(N_SHARDS, N_REDUNDANCY * N_SHARDS, BATCH_SHARD_SIZE)?;
-		// Note that sometime byte could stay set to non zero value, but it does not matter.
-		let mut shard_buff = [0u8; BATCH_SHARD_SIZE];
-
-		for segment in segments {
-			if processed_segments.contains(&(segment as usize)) {
-				continue;
-			}
-			let mut nb_chunk = 0;
-			let mut ori_map: std::collections::BTreeMap<usize, &[u8]> = Default::default();
-			// count all segments written, and stop at first segment having enough.
-			let mut run_segments = BTreeMap::new();
-
-			// Note this favor original chunks (firsts chunk_ix).
-			for (chunk_ix, chunks) in ori.iter().enumerate() {
-				let mut added = false;
-				{
-					if chunks.is_empty() {
-						continue;
-					}
-
-					let shard = if chunk_ix < N_SHARDS {
-						let s =
-							&self.shards_ori[chunk_ix] as *const _ as *mut [u8; BATCH_SHARD_SIZE];
-						// each shard are only accessed a single time here.
-						unsafe { s.as_mut().expect("non null") }
-					} else {
-						&mut shard_buff
-					};
-					for (segment_i, chunk) in chunks {
-						let segment_i = *segment_i as usize;
-						if nb_chunk == 0 {
-							if !processed_segments.contains(&segment_i) {
-								run_segments.insert(segment_i, 1);
-							} else {
-								continue;
-							}
-						} else if let Some(count) = run_segments.get_mut(&segment_i) {
-							if *count == nb_chunk {
-								*count += 1;
-							} else {
-								continue;
-							}
-						} else {
-							continue;
-						}
-
-						added = true;
-						let shard_i_s = segment_i * SUBSHARD_SIZE / SHARD_MIN_SIZE;
-						let shard_i_r = segment_i * SUBSHARD_SIZE % SHARD_MIN_SIZE;
-						let mut shard_i = shard_i_s * SHARD_MIN_SIZE + shard_i_r / POINT_SIZE;
-						for point_i in 0..SUBSHARD_POINTS {
-							shard[shard_i] = chunk[point_i * POINT_SIZE];
-							shard[shard_i + POINT_BYTE_SPACING] = chunk[(point_i * POINT_SIZE) + 1];
-							shard_i += 1;
-							if shard_i % POINT_BYTE_SPACING == 0 {
-								shard_i += POINT_BYTE_SPACING;
-							}
-						}
-					}
-				}
-				if !added {
-					continue;
-				}
-				if chunk_ix < N_SHARDS {
-					self.decoder.add_original_shard(chunk_ix, self.shards_ori[chunk_ix])?;
-					ori_map.insert(chunk_ix, &self.shards_ori[chunk_ix][..]);
-				} else {
-					self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, shard_buff)?;
-				}
-				nb_chunk += 1;
-				if nb_chunk == N_SHARDS {
-					// we stop at first match, we cannot
-					// attempt more as then we would not have matched completed
-					// shards.
-					break;
-				}
-			}
-			if nb_chunk != N_SHARDS {
-				self.decoder.reset(N_SHARDS, N_REDUNDANCY * N_SHARDS, BATCH_SHARD_SIZE)?;
-				// none added: we did not have a single segment with enough shards.
-				processed_segments.extend(run_segments.keys());
-				continue;
-			}
-			let ori_ret = self.decoder.decode()?;
-			nb_decode += 1;
-			// TODO modify deps to also access original data and avoid self.ori_shards buffer.
-			// Also to avoid instantiating ori_map container.
-			for (i, o) in ori_ret.restored_original_iter() {
-				ori_map.insert(i, o);
-			}
-			debug_assert_eq!(ori_map.len(), N_SHARDS);
-			for segment in run_segments.iter().filter(|v| *v.1 == N_SHARDS).map(|v| *v.0) {
-				let chunk_start = segment * SEGMENT_SIZE_ALIGNED;
-				let original = ori_chunk_to_data(&ori_map, chunk_start, Some(SEGMENT_SIZE))
-					.expect("number of segments checked");
-				result.push((
-					segment as u8,
-					Segment { data: Box::new(original), index: segment as u32 },
-				));
-				processed_segments.insert(segment);
-			}
-		}
-		assert_eq!(result, result2); 
-		Ok((result, nb_decode))
+		Ok((result2, nb_decode))
 	}
 }
 

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -187,28 +187,26 @@ impl SubShardDecoder {
 		I: Iterator<Item = (u8, ChunkIndex, &'a SubShard)>,
 	{
 		let mut ori = vec![Vec::new(); TOTAL_SHARDS];
-		let mut segments = BTreeSet::new();
-		let mut segments2 = BTreeMap::<u8, usize>::new();
+		let mut segments = BTreeMap::<u8, usize>::new();
 		let mut nb_decode = 0;
 
 		// TODO processed and run_segments could be skiped if we are sure to get
 		// correct number of chunks all for the same given chunk ix and segments.
 		for (segment, chunk_index, chunk) in subshards {
 			ori[chunk_index.0 as usize].push((segment, chunk));
-			segments.insert(segment);
-			*segments2.entry(segment).or_default() += 1;
+			*segments.entry(segment).or_default() += 1;
 		}
 
 		// make batches of segments
 		let mut segment_batches = Vec::new();
 
-		let mut processed_segments2 = BTreeSet::new();
+		let mut processed_segments = BTreeSet::new();
 		let mut nb_segments = 0;
-		for (segment, c) in segments2.iter() {
+		for (segment, c) in segments.iter() {
 			if *c >= N_SHARDS {
 				nb_segments += 1;
 			} else {
-				processed_segments2.insert(*segment);
+				processed_segments.insert(*segment);
 			}
 		}
 		while nb_segments > 0 {
@@ -218,9 +216,9 @@ impl SubShardDecoder {
 			for (_chunk_ix, chunks) in ori.iter().enumerate() {
 				let first = run_segments.is_empty();
 				for (segment_i, _chunk) in chunks {
-					if !processed_segments2.contains(segment_i) {
+					if !processed_segments.contains(segment_i) {
 						if first {
-							if !processed_segments2.contains(segment_i) {
+							if !processed_segments.contains(segment_i) {
 								run_segments.insert(*segment_i, 1);
 							}
 						} else {
@@ -243,7 +241,7 @@ impl SubShardDecoder {
 					break;
 				}
 				for (seg, _count) in run_segments.into_iter() {
-					processed_segments2.insert(seg);
+					processed_segments.insert(seg);
 				}
 				continue;
 			}
@@ -251,7 +249,7 @@ impl SubShardDecoder {
 			let mut segment_batch = BTreeSet::new();
 			for (seg, count) in run_segments.into_iter() {
 				if count == N_SHARDS {
-					processed_segments2.insert(seg);
+					processed_segments.insert(seg);
 					segment_batch.insert(seg);
 					if segment_batch.len() == 16 {
 						segment_batches.push(segment_batch);

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -92,29 +92,29 @@ impl SubShardEncoder {
 	/// Data must be less than MAX_SUB_OPTIMAL_SIZE_DATA.
 	pub fn construct_chunks(
 		&mut self,
-		data: &[Segment],
+		segments: &[Segment],
 	) -> Result<Vec<Box<[SubShard; TOTAL_SHARDS]>>, Error> {
-		if data.len() > SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL {
+		if segments.len() > SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL {
 			return Err(Error::BadPayload);
 		}
-		for (n, s) in data.iter().enumerate() {
+		for (n, s) in segments.iter().enumerate() {
 			if s.index as usize != n {
 				return Err(Error::BadPayload);
 			}
 		}
 		let mut result = vec![
 			Box::new([[0u8; SUBSHARD_SIZE]; TOTAL_SHARDS]);
-			SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL
+			segments.len()
 		];
 
 		let mut shard = [0u8; BATCH_SHARD_SIZE];
 		for shard_a in 0..N_SHARDS {
 			let mut shard_i = 0;
-			for segment_i in 0..data.len() {
+			for segment_i in 0..segments.len() {
 				for point_i in 0..SUBSHARD_POINTS {
 					let data_i = (point_i * N_SHARDS) * 2 + shard_a * 2;
 					let point = if data_i < SEGMENT_SIZE {
-						(data[segment_i].data[data_i], data[segment_i].data[data_i + 1])
+						(segments[segment_i].data[data_i], segments[segment_i].data[data_i + 1])
 					} else {
 						(0, 0)
 					};
@@ -146,6 +146,9 @@ impl SubShardEncoder {
 					result[segment_i][shard_a + N_SHARDS][point_i * 2 + 1] = point.1;
 				}
 				segment_i += 1;
+				if segment_i == segments.len() {
+					break;
+				}
 			}
 		}
 		Ok(result)

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 /// Fix segment size.
-const SEGMENT_SIZE: usize = 4096;
+pub const SEGMENT_SIZE: usize = 4096;
 
 const SUBSHARD_PER_SEGMENT: usize = ((SEGMENT_SIZE - 1) / SUBSHARD_SIZE) + 1;
 
@@ -19,13 +19,13 @@ const SUBSHARD_PER_SEGMENT: usize = ((SEGMENT_SIZE - 1) / SUBSHARD_SIZE) + 1;
 const SEGMENT_SIZE_ALIGNED: usize = SUBSHARD_PER_SEGMENT * SUBSHARD_SIZE; // 4104 byte
 
 /// Fix number of shards and subshards.
-const N_SHARDS: usize = 342;
+pub const N_SHARDS: usize = 342;
 
 /// The number of time the erasure coded shards we want.
-const N_REDUNDANCY: usize = 2;
+pub const N_REDUNDANCY: usize = 2;
 
 /// The total number of shards, both original and ec one.
-const TOTAL_SHARDS: usize = (1 + N_REDUNDANCY) * N_SHARDS;
+pub const TOTAL_SHARDS: usize = (1 + N_REDUNDANCY) * N_SHARDS;
 
 /// The reed-solomon library requires each shards to be 64 bytes aligned.
 const SHARD_MIN_SIZE: usize = SHARD_ALIGNMENT;
@@ -40,7 +40,7 @@ const SUBSHARD_POINTS: usize = 6;
 const POINT_SIZE: usize = 2; // gf16
 
 /// Size of a subshard in bytes.
-const SUBSHARD_SIZE: usize = POINT_SIZE * SUBSHARD_POINTS; // 12bytes
+pub const SUBSHARD_SIZE: usize = POINT_SIZE * SUBSHARD_POINTS; // 12bytes
 
 /// Aligned number of full shard to process subshard.
 const SUBSHARD_BATCH_MUL: usize = 3; // 3 * 12 is aligned with 64

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -1,0 +1,374 @@
+//! Manage subshards of 12 bytes of 4ko segments.
+//! Subshards are processed in to shards of 64 bytes
+//! to benefit from the simd optimisation in the
+//! best case.
+
+use super::*;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Fix segment size.
+const SEGMENT_SIZE: usize = 4096;
+
+const SUBSHARD_PER_SEGMENT: usize = ((SEGMENT_SIZE - 1) / SUBSHARD_SIZE) + 1;
+
+/// Segment size with added padding to allow being
+/// erasure coded in batch while staying on same points indexes.
+const SEGMENT_SIZE_ALIGNED: usize = SUBSHARD_PER_SEGMENT * SUBSHARD_SIZE; // 4104 byte
+
+/// Fix number of shards and subshards.
+const N_SHARDS: usize = 342;
+
+/// The number of time the erasure coded shards we want.
+const N_REDUNDANCY: usize = 2;
+
+/// The total number of shards, both original and ec one.
+const TOTAL_SHARDS: usize = (1 + N_REDUNDANCY) * N_SHARDS;
+
+/// The reed-solomon library requires each shards to be 64 bytes aligned.
+const SHARD_MIN_SIZE: usize = SHARD_ALIGNMENT;
+
+/// In shards lower and higher byte of each point are spaced for simd.
+const POINT_BYTE_SPACING: usize = SHARD_ALIGNMENT / 2;
+
+/// Number points in each subshards.
+const SUBSHARD_POINTS: usize = 6;
+
+/// Size of a point in bytes.
+const POINT_SIZE: usize = 2; // gf16
+
+/// Size of a subshard in bytes.
+const SUBSHARD_SIZE: usize = POINT_SIZE * SUBSHARD_POINTS; // 12bytes
+
+/// Aligned number of full shard to process subshard.
+const SUBSHARD_BATCH_MUL: usize = 3; // 3 * 12 is aligned with 64
+
+/// Number of segments in a aligned batch.
+const SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL: usize =
+	SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE / SUBSHARD_SIZE; // 16
+
+/// Fix size segment of a larger data.
+/// Data is padded when unaligned with
+/// the segment size.
+#[derive(PartialEq, Eq, Clone, Encode, Decode, Debug)]
+pub struct Segment {
+	/// Fix size chunk of data.
+	pub data: Box<[u8; SEGMENT_SIZE]>,
+	/// The index of this segment against its full data.
+	pub index: u32,
+}
+
+/// Subshard (points in sequential orders).
+pub type SubShard = [u8; SUBSHARD_SIZE];
+
+/// Subshard uses some temp memory, so these should be used multiple time instead of allocating.
+pub struct SubShardEncoder {
+	encoder: reed_solomon::ReedSolomonEncoder,
+}
+
+impl SubShardEncoder {
+	pub fn new() -> Result<Self, Error> {
+		Ok(Self {
+			encoder: reed_solomon::ReedSolomonEncoder::new(
+				N_SHARDS,
+				N_REDUNDANCY * N_SHARDS,
+				SHARD_MIN_SIZE * SUBSHARD_BATCH_MUL,
+			)?,
+		})
+	}
+
+	/// Construct erasure-coded chunks.
+	/// Segement input must be ordered by index and consecutive.
+	/// Data must be less than MAX_SUB_OPTIMAL_SIZE_DATA.
+	pub fn construct_chunks(
+		&mut self,
+		data: &[Segment],
+	) -> Result<Vec<Box<[SubShard; TOTAL_SHARDS]>>, Error> {
+		if data.len() > SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL {
+			return Err(Error::BadPayload);
+		}
+		let mut next = 0;
+		for s in data.iter() {
+			if s.index != next {
+				return Err(Error::BadPayload);
+			}
+			next += 1;
+		}
+		let mut result = vec![
+			Box::new([[0u8; SUBSHARD_SIZE]; TOTAL_SHARDS]);
+			SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL
+		];
+
+		let mut shard = [0u8; SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE];
+		for shard_a in 0..N_SHARDS {
+			let mut shard_i = 0;
+			for segment_i in 0..data.len() {
+				for point_i in 0..SUBSHARD_POINTS {
+					let data_i = (point_i * N_SHARDS) * 2 + shard_a * 2;
+					let point = if data_i < SEGMENT_SIZE {
+						(data[segment_i].data[data_i], data[segment_i].data[data_i + 1])
+					} else {
+						(0, 0)
+					};
+					shard[shard_i] = point.0;
+					shard[shard_i + POINT_BYTE_SPACING] = point.1;
+					result[segment_i][shard_a][point_i * 2] = point.0;
+					result[segment_i][shard_a][point_i * 2 + 1] = point.1;
+					shard_i += 1;
+					if shard_i % POINT_BYTE_SPACING == 0 {
+						shard_i += POINT_BYTE_SPACING;
+					}
+				}
+			}
+			self.encoder.add_original_shard(&shard)?;
+		}
+
+		let enco_res = self.encoder.encode()?;
+		for (shard_a, data) in enco_res.recovery_iter().enumerate() {
+			let mut segment_i = 0;
+			let mut data_i = 0;
+			while data_i != data.len() {
+				for point_i in 0..SUBSHARD_POINTS {
+					let point = (data[data_i], data[data_i + 32]);
+					data_i += 1;
+					if data_i % POINT_BYTE_SPACING == 0 {
+						data_i += POINT_BYTE_SPACING;
+					}
+					result[segment_i][shard_a + N_SHARDS][point_i * 2] = point.0;
+					result[segment_i][shard_a + N_SHARDS][point_i * 2 + 1] = point.1;
+				}
+				segment_i += 1;
+			}
+		}
+		return Ok(result);
+	}
+}
+
+/// Subshard uses some temp memory, so these should be used multiple time instead of allocating.
+pub struct SubShardDecoder {
+	decoder: reed_solomon::ReedSolomonDecoder,
+}
+
+impl SubShardDecoder {
+	pub fn new() -> Result<Self, Error> {
+		Ok(Self {
+			decoder: reed_solomon::ReedSolomonDecoder::new(
+				N_SHARDS,
+				N_REDUNDANCY * N_SHARDS,
+				SHARD_MIN_SIZE * SUBSHARD_BATCH_MUL,
+			)?,
+		})
+	}
+
+	// u8 is the segment number.
+	pub fn reconstruct<'a, I>(&mut self, subshards: &'a mut I) -> Result<Vec<(u8, Segment)>, Error>
+	where
+		I: Iterator<Item = (u8, ChunkIndex, &'a SubShard)>,
+	{
+		let mut ori = vec![Vec::new(); TOTAL_SHARDS];
+		let mut segments = BTreeSet::new();
+
+		// TODO processed and run_segments could be skiped if we are sure to get
+		// correct number of chunks all for the same given chunk ix and segments.
+		let mut processed_segments = BTreeSet::new();
+		for (segment, chunk_index, chunk) in subshards {
+			ori[chunk_index.0 as usize].push((segment, chunk));
+			segments.insert(segment);
+		}
+
+		let mut result = Vec::new();
+
+		// Note that sometime byte could stay set to non zero value, but it does not matter.
+		let mut shard = [0u8; SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE];
+
+		for segment in segments {
+			if processed_segments.contains(&(segment as usize)) {
+				continue;
+			}
+			let mut nb_chunk = 0;
+			let mut ori_map: std::collections::BTreeMap<usize, Vec<u8>> = Default::default();
+			// count all segments written, and stop at first segment having enough.
+			let mut run_segments = BTreeMap::new();
+
+			// Note this favor original chunks (firsts chunk_ix).
+			for (chunk_ix, chunks) in ori.iter().enumerate() {
+				if chunks.len() > 0 {
+					let mut added = false;
+					for (segment_i, chunk) in chunks {
+						let segment_i = *segment_i as usize;
+						if nb_chunk == 0 {
+							if !processed_segments.contains(&segment_i) {
+								run_segments.insert(segment_i, 1);
+							} else {
+								continue;
+							}
+						} else {
+							if let Some(count) = run_segments.get_mut(&segment_i) {
+								if *count == nb_chunk {
+									*count += 1;
+								} else {
+									continue;
+								}
+							} else {
+								continue;
+							}
+						}
+						added = true;
+						let shard_i_s = segment_i * SUBSHARD_SIZE / SHARD_MIN_SIZE;
+						let shard_i_r = segment_i * SUBSHARD_SIZE % SHARD_MIN_SIZE;
+						let mut shard_i = shard_i_s * SHARD_MIN_SIZE + shard_i_r / POINT_SIZE;
+						for point_i in 0..SUBSHARD_POINTS {
+							shard[shard_i] = chunk[point_i * POINT_SIZE];
+							shard[shard_i + POINT_BYTE_SPACING] = chunk[(point_i * POINT_SIZE) + 1];
+							shard_i += 1;
+							if shard_i % POINT_BYTE_SPACING == 0 {
+								shard_i += POINT_BYTE_SPACING;
+							}
+						}
+					}
+					if !added {
+						continue;
+					}
+					if chunk_ix < N_SHARDS {
+						self.decoder.add_original_shard(chunk_ix, &shard)?;
+						ori_map.insert(chunk_ix, shard.to_vec());
+					} else {
+						self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, &shard)?;
+					}
+					nb_chunk += 1;
+					if nb_chunk == N_SHARDS {
+						// we stop at first match, we cannot
+						// attempt more as then we would not have matched completed
+						// shards.
+						break;
+					}
+				}
+			}
+			if nb_chunk != N_SHARDS {
+				self.decoder.reset(
+					N_SHARDS,
+					N_REDUNDANCY * N_SHARDS,
+					SHARD_MIN_SIZE * SUBSHARD_BATCH_MUL,
+				)?;
+				// none added: we did not have a single segment with enough shards.
+				processed_segments.extend(run_segments.keys());
+				continue;
+			}
+			let ori_ret = self.decoder.decode()?;
+			for (i, o) in ori_ret.restored_original_iter() {
+				ori_map.insert(i, o.to_vec());
+			}
+			debug_assert_eq!(ori_map.len(), N_SHARDS);
+			for segment in run_segments.iter().filter(|v| *v.1 == N_SHARDS).map(|v| *v.0) {
+				let chunk_start = segment * SEGMENT_SIZE_ALIGNED;
+				let original = ori_chunk_to_data(&ori_map, chunk_start, Some(SEGMENT_SIZE))
+					.expect("number of segments checked");
+				result.push((
+					segment as u8,
+					Segment { data: Box::new(original), index: segment as u32 },
+				));
+				processed_segments.insert(segment);
+			}
+		}
+		Ok(result)
+	}
+}
+
+fn ori_chunk_to_data(
+	shards: &BTreeMap<usize, Vec<u8>>,
+	start_data: usize,
+	data_len: Option<usize>,
+) -> Option<[u8; 4096]> {
+	let mut data = [0u8; 4096];
+
+	let mut i_data = 0;
+	let (mut full_i, mut shard_i, mut shard_a) = data_index_to_chunk_index(start_data);
+	let mut shard_i_offset = full_i * SHARD_MIN_SIZE;
+	loop {
+		let Some(s) = shards.get(&shard_a) else {
+			return None;
+		};
+		let l = s[shard_i_offset + shard_i];
+		data[i_data] = l;
+		i_data += 1;
+		let r = s[shard_i_offset + shard_i + POINT_BYTE_SPACING];
+		data[i_data] = r;
+		i_data += 1;
+		if data_len.map(|m| i_data >= m).unwrap_or(false) {
+			break;
+		}
+		shard_a += 1;
+		if shard_a % N_SHARDS == 0 {
+			shard_i += 1;
+			if shard_i == POINT_BYTE_SPACING {
+				shard_i = 0;
+				full_i += 1;
+				if full_i == SUBSHARD_BATCH_MUL {
+					break;
+				}
+
+				shard_i_offset = full_i * SHARD_MIN_SIZE;
+			}
+			shard_a = 0;
+		}
+	}
+	Some(data)
+}
+
+// return chunk index among N_SHARDS (group of n , ix in slice, ix in n)
+fn data_index_to_chunk_index(index: usize) -> (usize, usize, usize) {
+	let shard_batch_size = SHARD_MIN_SIZE * N_SHARDS;
+	let a = index % shard_batch_size;
+	let b = a % (N_SHARDS * POINT_SIZE);
+	(index / shard_batch_size, a / (N_SHARDS * POINT_SIZE), b / POINT_SIZE)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_segments() {
+		for count in [1, 2, 4, 5, 10, 16] {
+			test_sc(count);
+		}
+	}
+
+	fn test_sc(nb_seg: usize) {
+		use rand::{rngs::SmallRng, Rng, SeedableRng};
+		let mut rng = SmallRng::from_seed([0; 32]);
+		let segments: Vec<_> = (0..nb_seg)
+			.map(|s| {
+				let mut se = [0u8; SEGMENT_SIZE];
+				rng.fill::<_>(&mut se[..]);
+
+				Segment { data: Box::new(se), index: s as u32 }
+			})
+			.collect();
+
+		let mut encoder = SubShardEncoder::new().unwrap();
+		let mut decoder = SubShardDecoder::new().unwrap();
+		let chunks = encoder.construct_chunks(&segments).unwrap();
+
+		// TODO test for all i_seg and combination of up to 16 i_seg
+		let i_seg = nb_seg / 2;
+
+		let mut it = (&chunks[i_seg][0..N_SHARDS / 3])
+			.iter()
+			.enumerate()
+			.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16), c))
+			.chain(
+				(&chunks[i_seg][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+					.iter()
+					.enumerate()
+					.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
+			)
+			.chain(
+				(&chunks[i_seg][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+					.iter()
+					.enumerate()
+					.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
+			);
+		let s = decoder.reconstruct(&mut it).unwrap();
+		assert_eq!((i_seg as u8, segments[i_seg].clone()), s[0]);
+	}
+}

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -86,12 +86,10 @@ impl SubShardEncoder {
 		if data.len() > SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL {
 			return Err(Error::BadPayload);
 		}
-		let mut next = 0;
-		for s in data.iter() {
-			if s.index != next {
+		for (n, s) in data.iter().enumerate() {
+			if s.index as usize != n {
 				return Err(Error::BadPayload);
 			}
-			next += 1;
 		}
 		let mut result = vec![
 			Box::new([[0u8; SUBSHARD_SIZE]; TOTAL_SHARDS]);
@@ -119,7 +117,7 @@ impl SubShardEncoder {
 					}
 				}
 			}
-			self.encoder.add_original_shard(&shard)?;
+			self.encoder.add_original_shard(shard)?;
 		}
 
 		let enco_res = self.encoder.encode()?;
@@ -139,7 +137,7 @@ impl SubShardEncoder {
 				segment_i += 1;
 			}
 		}
-		return Ok(result);
+		Ok(result)
 	}
 }
 
@@ -195,56 +193,56 @@ impl SubShardDecoder {
 
 			// Note this favor original chunks (firsts chunk_ix).
 			for (chunk_ix, chunks) in ori.iter().enumerate() {
-				if chunks.len() > 0 {
-					let mut added = false;
-					for (segment_i, chunk) in chunks {
-						let segment_i = *segment_i as usize;
-						if nb_chunk == 0 {
-							if !processed_segments.contains(&segment_i) {
-								run_segments.insert(segment_i, 1);
-							} else {
-								continue;
-							}
+				if chunks.is_empty() {
+					continue;
+				}
+				let mut added = false;
+				for (segment_i, chunk) in chunks {
+					let segment_i = *segment_i as usize;
+					if nb_chunk == 0 {
+						if !processed_segments.contains(&segment_i) {
+							run_segments.insert(segment_i, 1);
 						} else {
-							if let Some(count) = run_segments.get_mut(&segment_i) {
-								if *count == nb_chunk {
-									*count += 1;
-								} else {
-									continue;
-								}
-							} else {
-								continue;
-							}
+							continue;
 						}
-						added = true;
-						let shard_i_s = segment_i * SUBSHARD_SIZE / SHARD_MIN_SIZE;
-						let shard_i_r = segment_i * SUBSHARD_SIZE % SHARD_MIN_SIZE;
-						let mut shard_i = shard_i_s * SHARD_MIN_SIZE + shard_i_r / POINT_SIZE;
-						for point_i in 0..SUBSHARD_POINTS {
-							shard[shard_i] = chunk[point_i * POINT_SIZE];
-							shard[shard_i + POINT_BYTE_SPACING] = chunk[(point_i * POINT_SIZE) + 1];
-							shard_i += 1;
-							if shard_i % POINT_BYTE_SPACING == 0 {
-								shard_i += POINT_BYTE_SPACING;
-							}
+					} else if let Some(count) = run_segments.get_mut(&segment_i) {
+						if *count == nb_chunk {
+							*count += 1;
+						} else {
+							continue;
 						}
-					}
-					if !added {
+					} else {
 						continue;
 					}
-					if chunk_ix < N_SHARDS {
-						self.decoder.add_original_shard(chunk_ix, &shard)?;
-						ori_map.insert(chunk_ix, shard.to_vec());
-					} else {
-						self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, &shard)?;
+
+					added = true;
+					let shard_i_s = segment_i * SUBSHARD_SIZE / SHARD_MIN_SIZE;
+					let shard_i_r = segment_i * SUBSHARD_SIZE % SHARD_MIN_SIZE;
+					let mut shard_i = shard_i_s * SHARD_MIN_SIZE + shard_i_r / POINT_SIZE;
+					for point_i in 0..SUBSHARD_POINTS {
+						shard[shard_i] = chunk[point_i * POINT_SIZE];
+						shard[shard_i + POINT_BYTE_SPACING] = chunk[(point_i * POINT_SIZE) + 1];
+						shard_i += 1;
+						if shard_i % POINT_BYTE_SPACING == 0 {
+							shard_i += POINT_BYTE_SPACING;
+						}
 					}
-					nb_chunk += 1;
-					if nb_chunk == N_SHARDS {
-						// we stop at first match, we cannot
-						// attempt more as then we would not have matched completed
-						// shards.
-						break;
-					}
+				}
+				if !added {
+					continue;
+				}
+				if chunk_ix < N_SHARDS {
+					self.decoder.add_original_shard(chunk_ix, shard)?;
+					ori_map.insert(chunk_ix, shard.to_vec());
+				} else {
+					self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, shard)?;
+				}
+				nb_chunk += 1;
+				if nb_chunk == N_SHARDS {
+					// we stop at first match, we cannot
+					// attempt more as then we would not have matched completed
+					// shards.
+					break;
 				}
 			}
 			if nb_chunk != N_SHARDS {
@@ -289,9 +287,7 @@ fn ori_chunk_to_data(
 	let (mut full_i, mut shard_i, mut shard_a) = data_index_to_chunk_index(start_data);
 	let mut shard_i_offset = full_i * SHARD_MIN_SIZE;
 	loop {
-		let Some(s) = shards.get(&shard_a) else {
-			return None;
-		};
+		let s = shards.get(&shard_a)?;
 		let l = s[shard_i_offset + shard_i];
 		data[i_data] = l;
 		i_data += 1;

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -4,7 +4,10 @@
 //! best case.
 
 use super::*;
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+	collections::{BTreeMap, BTreeSet},
+	mem::MaybeUninit,
+};
 
 /// Fix segment size.
 const SEGMENT_SIZE: usize = 4096;
@@ -45,6 +48,8 @@ const SUBSHARD_BATCH_MUL: usize = 3; // 3 * 12 is aligned with 64
 /// Number of segments in a aligned batch.
 const SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL: usize =
 	SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE / SUBSHARD_SIZE; // 16
+													 //
+const BATCH_SHARD_SIZE: usize = SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE; // 192
 
 /// Fix size segment of a larger data.
 /// Data is padded when unaligned with
@@ -71,7 +76,7 @@ impl SubShardEncoder {
 			encoder: reed_solomon::ReedSolomonEncoder::new(
 				N_SHARDS,
 				N_REDUNDANCY * N_SHARDS,
-				SHARD_MIN_SIZE * SUBSHARD_BATCH_MUL,
+				BATCH_SHARD_SIZE,
 			)?,
 		})
 	}
@@ -96,7 +101,7 @@ impl SubShardEncoder {
 			SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL
 		];
 
-		let mut shard = [0u8; SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE];
+		let mut shard = [0u8; BATCH_SHARD_SIZE];
 		for shard_a in 0..N_SHARDS {
 			let mut shard_i = 0;
 			for segment_i in 0..data.len() {
@@ -144,16 +149,26 @@ impl SubShardEncoder {
 /// Subshard uses some temp memory, so these should be used multiple time instead of allocating.
 pub struct SubShardDecoder {
 	decoder: reed_solomon::ReedSolomonDecoder,
+	// cannot access ori shards from decoder, copying them here.
+	shards_ori: [[u8; BATCH_SHARD_SIZE]; N_SHARDS],
 }
 
 impl SubShardDecoder {
 	pub fn new() -> Result<Self, Error> {
+		let mut shards: [MaybeUninit<[u8; BATCH_SHARD_SIZE]>; N_SHARDS] =
+			unsafe { MaybeUninit::uninit().assume_init() };
+
+		for i in 0..N_SHARDS {
+			shards[i].write([0u8; BATCH_SHARD_SIZE]);
+		}
+
 		Ok(Self {
 			decoder: reed_solomon::ReedSolomonDecoder::new(
 				N_SHARDS,
 				N_REDUNDANCY * N_SHARDS,
-				SHARD_MIN_SIZE * SUBSHARD_BATCH_MUL,
+				BATCH_SHARD_SIZE,
 			)?,
+			shards_ori: unsafe { std::mem::transmute(shards) },
 		})
 	}
 
@@ -180,51 +195,61 @@ impl SubShardDecoder {
 		let mut result = Vec::new();
 
 		// Note that sometime byte could stay set to non zero value, but it does not matter.
-		let mut shard = [0u8; SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE];
+		let mut shard_buff = [0u8; BATCH_SHARD_SIZE];
 
 		for segment in segments {
 			if processed_segments.contains(&(segment as usize)) {
 				continue;
 			}
 			let mut nb_chunk = 0;
-			let mut ori_map: std::collections::BTreeMap<usize, Vec<u8>> = Default::default();
+			let mut ori_map: std::collections::BTreeMap<usize, &[u8]> = Default::default();
 			// count all segments written, and stop at first segment having enough.
 			let mut run_segments = BTreeMap::new();
 
 			// Note this favor original chunks (firsts chunk_ix).
 			for (chunk_ix, chunks) in ori.iter().enumerate() {
-				if chunks.is_empty() {
-					continue;
-				}
 				let mut added = false;
-				for (segment_i, chunk) in chunks {
-					let segment_i = *segment_i as usize;
-					if nb_chunk == 0 {
-						if !processed_segments.contains(&segment_i) {
-							run_segments.insert(segment_i, 1);
-						} else {
-							continue;
-						}
-					} else if let Some(count) = run_segments.get_mut(&segment_i) {
-						if *count == nb_chunk {
-							*count += 1;
-						} else {
-							continue;
-						}
+				{
+					let shard = if chunk_ix < N_SHARDS {
+						let s = &self.shards_ori[chunk_ix] as *const [u8; BATCH_SHARD_SIZE]
+							as *mut [u8; BATCH_SHARD_SIZE];
+						// each shard are only accessed a single time here.
+						unsafe { std::mem::transmute(s) }
 					} else {
+						&mut shard_buff
+					};
+					if chunks.is_empty() {
 						continue;
 					}
+					for (segment_i, chunk) in chunks {
+						let segment_i = *segment_i as usize;
+						if nb_chunk == 0 {
+							if !processed_segments.contains(&segment_i) {
+								run_segments.insert(segment_i, 1);
+							} else {
+								continue;
+							}
+						} else if let Some(count) = run_segments.get_mut(&segment_i) {
+							if *count == nb_chunk {
+								*count += 1;
+							} else {
+								continue;
+							}
+						} else {
+							continue;
+						}
 
-					added = true;
-					let shard_i_s = segment_i * SUBSHARD_SIZE / SHARD_MIN_SIZE;
-					let shard_i_r = segment_i * SUBSHARD_SIZE % SHARD_MIN_SIZE;
-					let mut shard_i = shard_i_s * SHARD_MIN_SIZE + shard_i_r / POINT_SIZE;
-					for point_i in 0..SUBSHARD_POINTS {
-						shard[shard_i] = chunk[point_i * POINT_SIZE];
-						shard[shard_i + POINT_BYTE_SPACING] = chunk[(point_i * POINT_SIZE) + 1];
-						shard_i += 1;
-						if shard_i % POINT_BYTE_SPACING == 0 {
-							shard_i += POINT_BYTE_SPACING;
+						added = true;
+						let shard_i_s = segment_i * SUBSHARD_SIZE / SHARD_MIN_SIZE;
+						let shard_i_r = segment_i * SUBSHARD_SIZE % SHARD_MIN_SIZE;
+						let mut shard_i = shard_i_s * SHARD_MIN_SIZE + shard_i_r / POINT_SIZE;
+						for point_i in 0..SUBSHARD_POINTS {
+							shard[shard_i] = chunk[point_i * POINT_SIZE];
+							shard[shard_i + POINT_BYTE_SPACING] = chunk[(point_i * POINT_SIZE) + 1];
+							shard_i += 1;
+							if shard_i % POINT_BYTE_SPACING == 0 {
+								shard_i += POINT_BYTE_SPACING;
+							}
 						}
 					}
 				}
@@ -232,10 +257,10 @@ impl SubShardDecoder {
 					continue;
 				}
 				if chunk_ix < N_SHARDS {
-					self.decoder.add_original_shard(chunk_ix, shard)?;
-					ori_map.insert(chunk_ix, shard.to_vec());
+					self.decoder.add_original_shard(chunk_ix, &self.shards_ori[chunk_ix])?;
+					ori_map.insert(chunk_ix, &self.shards_ori[chunk_ix][..]);
 				} else {
-					self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, shard)?;
+					self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, &shard_buff)?;
 				}
 				nb_chunk += 1;
 				if nb_chunk == N_SHARDS {
@@ -246,11 +271,7 @@ impl SubShardDecoder {
 				}
 			}
 			if nb_chunk != N_SHARDS {
-				self.decoder.reset(
-					N_SHARDS,
-					N_REDUNDANCY * N_SHARDS,
-					SHARD_MIN_SIZE * SUBSHARD_BATCH_MUL,
-				)?;
+				self.decoder.reset(N_SHARDS, N_REDUNDANCY * N_SHARDS, BATCH_SHARD_SIZE)?;
 				// none added: we did not have a single segment with enough shards.
 				processed_segments.extend(run_segments.keys());
 				continue;
@@ -258,7 +279,7 @@ impl SubShardDecoder {
 			let ori_ret = self.decoder.decode()?;
 			nb_decode += 1;
 			for (i, o) in ori_ret.restored_original_iter() {
-				ori_map.insert(i, o.to_vec());
+				ori_map.insert(i, o);
 			}
 			debug_assert_eq!(ori_map.len(), N_SHARDS);
 			for segment in run_segments.iter().filter(|v| *v.1 == N_SHARDS).map(|v| *v.0) {
@@ -277,7 +298,7 @@ impl SubShardDecoder {
 }
 
 fn ori_chunk_to_data(
-	shards: &BTreeMap<usize, Vec<u8>>,
+	shards: &BTreeMap<usize, &[u8]>,
 	start_data: usize,
 	data_len: Option<usize>,
 ) -> Option<[u8; 4096]> {

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -158,8 +158,8 @@ impl SubShardDecoder {
 		let mut shards: [MaybeUninit<[u8; BATCH_SHARD_SIZE]>; N_SHARDS] =
 			unsafe { MaybeUninit::uninit().assume_init() };
 
-		for i in 0..N_SHARDS {
-			shards[i].write([0u8; BATCH_SHARD_SIZE]);
+		for shard in shards.iter_mut() {
+			shard.write([0u8; BATCH_SHARD_SIZE]);
 		}
 
 		Ok(Self {
@@ -211,10 +211,10 @@ impl SubShardDecoder {
 				let mut added = false;
 				{
 					let shard = if chunk_ix < N_SHARDS {
-						let s = &self.shards_ori[chunk_ix] as *const [u8; BATCH_SHARD_SIZE]
-							as *mut [u8; BATCH_SHARD_SIZE];
+						let s =
+							&self.shards_ori[chunk_ix] as *const _ as *mut [u8; BATCH_SHARD_SIZE];
 						// each shard are only accessed a single time here.
-						unsafe { std::mem::transmute(s) }
+						unsafe { s.as_mut().expect("non null") }
 					} else {
 						&mut shard_buff
 					};
@@ -257,10 +257,10 @@ impl SubShardDecoder {
 					continue;
 				}
 				if chunk_ix < N_SHARDS {
-					self.decoder.add_original_shard(chunk_ix, &self.shards_ori[chunk_ix])?;
+					self.decoder.add_original_shard(chunk_ix, self.shards_ori[chunk_ix])?;
 					ori_map.insert(chunk_ix, &self.shards_ori[chunk_ix][..]);
 				} else {
-					self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, &shard_buff)?;
+					self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, shard_buff)?;
 				}
 				nb_chunk += 1;
 				if nb_chunk == N_SHARDS {

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -160,12 +160,16 @@ impl SubShardDecoder {
 	}
 
 	// u8 is the segment number.
-	pub fn reconstruct<'a, I>(&mut self, subshards: &'a mut I) -> Result<Vec<(u8, Segment)>, Error>
+	pub fn reconstruct<'a, I>(
+		&mut self,
+		subshards: &'a mut I,
+	) -> Result<(Vec<(u8, Segment)>, usize), Error>
 	where
 		I: Iterator<Item = (u8, ChunkIndex, &'a SubShard)>,
 	{
 		let mut ori = vec![Vec::new(); TOTAL_SHARDS];
 		let mut segments = BTreeSet::new();
+		let mut nb_decode = 0;
 
 		// TODO processed and run_segments could be skiped if we are sure to get
 		// correct number of chunks all for the same given chunk ix and segments.
@@ -254,6 +258,7 @@ impl SubShardDecoder {
 				continue;
 			}
 			let ori_ret = self.decoder.decode()?;
+			nb_decode += 1;
 			for (i, o) in ori_ret.restored_original_iter() {
 				ori_map.insert(i, o.to_vec());
 			}
@@ -269,7 +274,7 @@ impl SubShardDecoder {
 				processed_segments.insert(segment);
 			}
 		}
-		Ok(result)
+		Ok((result, nb_decode))
 	}
 }
 
@@ -366,7 +371,8 @@ mod tests {
 						.enumerate()
 						.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
 				);
-			let s = decoder.reconstruct(&mut it).unwrap();
+			let (s, i) = decoder.reconstruct(&mut it).unwrap();
+			assert_eq!(i, 1);
 			assert_eq!((i_seg as u8, segments[i_seg].clone()), s[0]);
 		}
 		// try batching 2 subchunk
@@ -409,7 +415,8 @@ mod tests {
 					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
 			);
 
-		let s = decoder.reconstruct(&mut it1.chain(it2)).unwrap();
+		let (s, i) = decoder.reconstruct(&mut it1.chain(it2)).unwrap();
+		assert_eq!(i, 1); // all chunk ix are aligned so can be processed at once.
 		assert_eq!((i_seg1 as u8, segments[i_seg1].clone()), s[0]);
 		assert_eq!((i_seg2 as u8, segments[i_seg2].clone()), s[1]);
 	}

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -349,26 +349,68 @@ mod tests {
 		let mut decoder = SubShardDecoder::new().unwrap();
 		let chunks = encoder.construct_chunks(&segments).unwrap();
 
-		// TODO test for all i_seg and combination of up to 16 i_seg
-		let i_seg = nb_seg / 2;
+		for i_seg in 0..nb_seg {
+			let mut it = (&chunks[i_seg][0..N_SHARDS / 3])
+				.iter()
+				.enumerate()
+				.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16), c))
+				.chain(
+					(&chunks[i_seg][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+						.iter()
+						.enumerate()
+						.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
+				)
+				.chain(
+					(&chunks[i_seg][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+						.iter()
+						.enumerate()
+						.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
+				);
+			let s = decoder.reconstruct(&mut it).unwrap();
+			assert_eq!((i_seg as u8, segments[i_seg].clone()), s[0]);
+		}
+		// try batching 2 subchunk
+		if nb_seg < 2 {
+			return;
+		}
+		let i_seg1 = 0;
+		let i_seg2 = nb_seg / 2;
 
-		let mut it = (&chunks[i_seg][0..N_SHARDS / 3])
+		let it1 = (&chunks[i_seg1][0..N_SHARDS / 3])
 			.iter()
 			.enumerate()
-			.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16), c))
+			.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16), c))
 			.chain(
-				(&chunks[i_seg][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+				(&chunks[i_seg1][N_SHARDS..N_SHARDS + N_SHARDS / 3])
 					.iter()
 					.enumerate()
-					.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
+					.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
 			)
 			.chain(
-				(&chunks[i_seg][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+				(&chunks[i_seg1][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
 					.iter()
 					.enumerate()
-					.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
+					.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
 			);
-		let s = decoder.reconstruct(&mut it).unwrap();
-		assert_eq!((i_seg as u8, segments[i_seg].clone()), s[0]);
+		let it2 = (&chunks[i_seg2][0..N_SHARDS / 3])
+			.iter()
+			.enumerate()
+			.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16), c))
+			.chain(
+				(&chunks[i_seg2][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+					.iter()
+					.enumerate()
+					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
+			)
+			.chain(
+				(&chunks[i_seg2][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+					.iter()
+					.enumerate()
+					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
+			);
+
+		let s = decoder.reconstruct(&mut it1.chain(it2)).unwrap();
+		assert_eq!((i_seg1 as u8, segments[i_seg1].clone()), s[0]);
+		assert_eq!((i_seg2 as u8, segments[i_seg2].clone()), s[1]);
 	}
 }

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -278,6 +278,8 @@ impl SubShardDecoder {
 			}
 			let ori_ret = self.decoder.decode()?;
 			nb_decode += 1;
+			// TODO modify deps to also access original data and avoid self.ori_shards buffer.
+			// Also to avoid instantiating ori_map container.
 			for (i, o) in ori_ret.restored_original_iter() {
 				ori_map.insert(i, o);
 			}

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -51,11 +51,10 @@ const SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL: usize =
 													 //
 const BATCH_SHARD_SIZE: usize = SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE; // 192
 
-
 const SUBSHARD_BATCH_MUL1: usize = SHARD_MIN_SIZE / SUBSHARD_SIZE; // 64 / 12, only 5
 const BATCH_SHARD_SIZE_1: usize = SHARD_MIN_SIZE; // 192
 const SUBSHARD_BATCH_MUL2: usize = (SHARD_MIN_SIZE * 2) / SUBSHARD_SIZE; // 128 / 12, only 10
-const BATCH_SHARD_SIZE_2: usize = 2*SHARD_MIN_SIZE; // 192
+const BATCH_SHARD_SIZE_2: usize = 2 * SHARD_MIN_SIZE; // 192
 
 /// Fix size segment of a larger data.
 /// Data is padded when unaligned with
@@ -74,11 +73,13 @@ pub type SubShard = [u8; SUBSHARD_SIZE];
 /// Subshard uses some temp memory, so these should be used multiple time instead of allocating.
 pub struct SubShardEncoder {
 	encoder: reed_solomon::ReedSolomonEncoder,
+	last_shard_size: usize,
 }
 
 impl SubShardEncoder {
 	pub fn new() -> Result<Self, Error> {
 		Ok(Self {
+			last_shard_size: BATCH_SHARD_SIZE,
 			encoder: reed_solomon::ReedSolomonEncoder::new(
 				N_SHARDS,
 				N_REDUNDANCY * N_SHARDS,
@@ -88,68 +89,76 @@ impl SubShardEncoder {
 	}
 
 	/// Construct erasure-coded chunks.
-	/// Segement input must be ordered by index and consecutive.
-	/// Data must be less than MAX_SUB_OPTIMAL_SIZE_DATA.
+	/// Resulting in groups of subshard per input segments.
 	pub fn construct_chunks(
 		&mut self,
 		segments: &[Segment],
 	) -> Result<Vec<Box<[SubShard; TOTAL_SHARDS]>>, Error> {
-		if segments.len() > SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL {
-			return Err(Error::BadPayload);
-		}
-		for (n, s) in segments.iter().enumerate() {
-			if s.index as usize != n {
-				return Err(Error::BadPayload);
-			}
-		}
-		let mut result = vec![
-			Box::new([[0u8; SUBSHARD_SIZE]; TOTAL_SHARDS]);
-			segments.len()
-		];
+		let mut result = vec![Box::new([[0u8; SUBSHARD_SIZE]; TOTAL_SHARDS]); segments.len()];
 
+		let mut seg_offset = 0;
 		let mut shard = [0u8; BATCH_SHARD_SIZE];
-		for shard_a in 0..N_SHARDS {
-			let mut shard_i = 0;
-			for segment_i in 0..segments.len() {
-				for point_i in 0..SUBSHARD_POINTS {
-					let data_i = (point_i * N_SHARDS) * 2 + shard_a * 2;
-					let point = if data_i < SEGMENT_SIZE {
-						(segments[segment_i].data[data_i], segments[segment_i].data[data_i + 1])
-					} else {
-						(0, 0)
-					};
-					shard[shard_i] = point.0;
-					shard[shard_i + POINT_BYTE_SPACING] = point.1;
-					result[segment_i][shard_a][point_i * 2] = point.0;
-					result[segment_i][shard_a][point_i * 2 + 1] = point.1;
-					shard_i += 1;
-					if shard_i % POINT_BYTE_SPACING == 0 {
-						shard_i += POINT_BYTE_SPACING;
-					}
-				}
+		for segments in segments.chunks(SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL) {
+			let s = if segments.len() <= SUBSHARD_BATCH_MUL1 {
+				// 1 *
+				BATCH_SHARD_SIZE_1
+			} else if segments.len() <= SUBSHARD_BATCH_MUL2 {
+				// 2 *
+				BATCH_SHARD_SIZE_2
+			} else {
+				// 3 *
+				BATCH_SHARD_SIZE
+			};
+			if self.last_shard_size != s {
+				self.encoder.reset(N_SHARDS, N_REDUNDANCY * N_SHARDS, s)?;
+				self.last_shard_size = s;
 			}
-			self.encoder.add_original_shard(shard)?;
-		}
 
-		let enco_res = self.encoder.encode()?;
-		for (shard_a, data) in enco_res.recovery_iter().enumerate() {
-			let mut segment_i = 0;
-			let mut data_i = 0;
-			while data_i != data.len() {
-				for point_i in 0..SUBSHARD_POINTS {
-					let point = (data[data_i], data[data_i + 32]);
-					data_i += 1;
-					if data_i % POINT_BYTE_SPACING == 0 {
-						data_i += POINT_BYTE_SPACING;
+			for shard_a in 0..N_SHARDS {
+				let mut shard_i = 0;
+				for segment_i in 0..segments.len() {
+					for point_i in 0..SUBSHARD_POINTS {
+						let data_i = (point_i * N_SHARDS) * 2 + shard_a * 2;
+						let point = if data_i < SEGMENT_SIZE {
+							(segments[segment_i].data[data_i], segments[segment_i].data[data_i + 1])
+						} else {
+							(0, 0)
+						};
+						shard[shard_i] = point.0;
+						shard[shard_i + POINT_BYTE_SPACING] = point.1;
+						result[seg_offset + segment_i][shard_a][point_i * 2] = point.0;
+						result[seg_offset + segment_i][shard_a][point_i * 2 + 1] = point.1;
+						shard_i += 1;
+						if shard_i % POINT_BYTE_SPACING == 0 {
+							shard_i += POINT_BYTE_SPACING;
+						}
 					}
-					result[segment_i][shard_a + N_SHARDS][point_i * 2] = point.0;
-					result[segment_i][shard_a + N_SHARDS][point_i * 2 + 1] = point.1;
 				}
-				segment_i += 1;
-				if segment_i == segments.len() {
-					break;
+				self.encoder.add_original_shard(&shard[..s])?;
+			}
+
+			let enco_res = self.encoder.encode()?;
+			for (shard_a, data) in enco_res.recovery_iter().enumerate() {
+				let mut segment_i = 0;
+				let mut data_i = 0;
+				while data_i != data.len() {
+					for point_i in 0..SUBSHARD_POINTS {
+						let point = (data[data_i], data[data_i + 32]);
+						data_i += 1;
+						if data_i % POINT_BYTE_SPACING == 0 {
+							data_i += POINT_BYTE_SPACING;
+						}
+						result[seg_offset + segment_i][shard_a + N_SHARDS][point_i * 2] = point.0;
+						result[seg_offset + segment_i][shard_a + N_SHARDS][point_i * 2 + 1] =
+							point.1;
+					}
+					segment_i += 1;
+					if segment_i == segments.len() {
+						break;
+					}
 				}
 			}
+			seg_offset += SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL;
 		}
 		Ok(result)
 	}
@@ -160,6 +169,7 @@ pub struct SubShardDecoder {
 	decoder: reed_solomon::ReedSolomonDecoder,
 	// cannot access ori shards from decoder, copying them here.
 	shards_ori: [[u8; BATCH_SHARD_SIZE]; N_SHARDS],
+	last_shard_size: usize,
 }
 
 impl SubShardDecoder {
@@ -172,6 +182,7 @@ impl SubShardDecoder {
 		}
 
 		Ok(Self {
+			last_shard_size: BATCH_SHARD_SIZE,
 			decoder: reed_solomon::ReedSolomonDecoder::new(
 				N_SHARDS,
 				N_REDUNDANCY * N_SHARDS,
@@ -278,14 +289,16 @@ impl SubShardDecoder {
 				// 1 *
 				BATCH_SHARD_SIZE_1
 			} else if segments.len() <= SUBSHARD_BATCH_MUL2 {
-				// 2 * 
+				// 2 *
 				BATCH_SHARD_SIZE_2
 			} else {
-				// 3 * 
+				// 3 *
 				BATCH_SHARD_SIZE
 			};
-			// TODO only reset if s different from prev
-			self.decoder.reset(N_SHARDS, N_REDUNDANCY * N_SHARDS, s)?;
+			if s != self.last_shard_size {
+				self.decoder.reset(N_SHARDS, N_REDUNDANCY * N_SHARDS, s)?;
+				self.last_shard_size = s;
+			}
 			let mut nb_chunk = 0;
 			let mut ori_map: std::collections::BTreeMap<usize, &[u8]> = Default::default();
 			for (chunk_ix, chunks) in ori.iter().enumerate() {
@@ -319,7 +332,8 @@ impl SubShardDecoder {
 				debug_assert!(nb == 0 || nb == segments.len());
 				if nb > 0 {
 					if chunk_ix < N_SHARDS {
-						self.decoder.add_original_shard(chunk_ix, &self.shards_ori[chunk_ix][..s])?;
+						self.decoder
+							.add_original_shard(chunk_ix, &self.shards_ori[chunk_ix][..s])?;
 						ori_map.insert(chunk_ix, &self.shards_ori[chunk_ix][..]);
 					} else {
 						self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, &shard_buff[..s])?;
@@ -339,7 +353,7 @@ impl SubShardDecoder {
 				ori_map.insert(i, o);
 			}
 			debug_assert_eq!(ori_map.len(), N_SHARDS);
-			for (i, segment) in segments.iter().enumerate()  {
+			for (i, segment) in segments.iter().enumerate() {
 				let chunk_start = i * SEGMENT_SIZE_ALIGNED;
 				let original = ori_chunk_to_data(&ori_map, chunk_start, Some(SEGMENT_SIZE))
 					.expect("number of segments checked");
@@ -348,7 +362,6 @@ impl SubShardDecoder {
 					Segment { data: Box::new(original), index: *segment as u32 },
 				));
 			}
-
 		}
 
 		Ok((result2, nb_decode))

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -51,6 +51,12 @@ const SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL: usize =
 													 //
 const BATCH_SHARD_SIZE: usize = SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE; // 192
 
+
+const SUBSHARD_BATCH_MUL1: usize = SHARD_MIN_SIZE / SUBSHARD_SIZE; // 64 / 12, only 5
+const BATCH_SHARD_SIZE_1: usize = SHARD_MIN_SIZE; // 192
+const SUBSHARD_BATCH_MUL2: usize = (SHARD_MIN_SIZE * 2) / SUBSHARD_SIZE; // 128 / 12, only 10
+const BATCH_SHARD_SIZE_2: usize = 2*SHARD_MIN_SIZE; // 192
+
 /// Fix size segment of a larger data.
 /// Data is padded when unaligned with
 /// the segment size.
@@ -267,6 +273,18 @@ impl SubShardDecoder {
 		// Note that sometime byte could stay set to non zero value, but it does not matter.
 		let mut shard_buff = [0u8; BATCH_SHARD_SIZE];
 		for segments in segment_batches {
+			let s = if segments.len() <= SUBSHARD_BATCH_MUL1 {
+				// 1 *
+				BATCH_SHARD_SIZE_1
+			} else if segments.len() <= SUBSHARD_BATCH_MUL2 {
+				// 2 * 
+				BATCH_SHARD_SIZE_2
+			} else {
+				// 3 * 
+				BATCH_SHARD_SIZE
+			};
+			// TODO only reset if s different from prev
+			self.decoder.reset(N_SHARDS, N_REDUNDANCY * N_SHARDS, s)?;
 			let mut nb_chunk = 0;
 			let mut ori_map: std::collections::BTreeMap<usize, &[u8]> = Default::default();
 			for (chunk_ix, chunks) in ori.iter().enumerate() {
@@ -300,10 +318,10 @@ impl SubShardDecoder {
 				debug_assert!(nb == 0 || nb == segments.len());
 				if nb > 0 {
 					if chunk_ix < N_SHARDS {
-						self.decoder.add_original_shard(chunk_ix, self.shards_ori[chunk_ix])?;
+						self.decoder.add_original_shard(chunk_ix, &self.shards_ori[chunk_ix][..s])?;
 						ori_map.insert(chunk_ix, &self.shards_ori[chunk_ix][..]);
 					} else {
-						self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, shard_buff)?;
+						self.decoder.add_recovery_shard(chunk_ix - N_SHARDS, &shard_buff[..s])?;
 					}
 					nb_chunk += 1;
 					if nb_chunk == N_SHARDS {
@@ -333,6 +351,7 @@ impl SubShardDecoder {
 
 		let mut result = Vec::new();
 
+		self.decoder.reset(N_SHARDS, N_REDUNDANCY * N_SHARDS, BATCH_SHARD_SIZE)?;
 		// Note that sometime byte could stay set to non zero value, but it does not matter.
 		let mut shard_buff = [0u8; BATCH_SHARD_SIZE];
 

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -48,7 +48,7 @@ const SUBSHARD_BATCH_MUL: usize = 3; // 3 * 12 is aligned with 64
 /// Number of segments in a aligned batch.
 const SEGMENTS_PER_SUBSHARD_BATCH_OPTIMAL: usize =
 	SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE / SUBSHARD_SIZE; // 16
-													 //
+
 const BATCH_SHARD_SIZE: usize = SUBSHARD_BATCH_MUL * SHARD_MIN_SIZE; // 192
 
 const SUBSHARD_BATCH_MUL1: usize = SHARD_MIN_SIZE / SUBSHARD_SIZE; // 64 / 12, only 5

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -351,18 +351,18 @@ mod tests {
 		let chunks = encoder.construct_chunks(&segments).unwrap();
 
 		for i_seg in 0..nb_seg {
-			let mut it = (&chunks[i_seg][0..N_SHARDS / 3])
+			let mut it = (chunks[i_seg][0..N_SHARDS / 3])
 				.iter()
 				.enumerate()
 				.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16), c))
 				.chain(
-					(&chunks[i_seg][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+					(chunks[i_seg][N_SHARDS..N_SHARDS + N_SHARDS / 3])
 						.iter()
 						.enumerate()
 						.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
 				)
 				.chain(
-					(&chunks[i_seg][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+					(chunks[i_seg][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
 						.iter()
 						.enumerate()
 						.map(|(i, c)| (i_seg as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
@@ -378,34 +378,34 @@ mod tests {
 		let i_seg1 = 0;
 		let i_seg2 = nb_seg / 2;
 
-		let it1 = (&chunks[i_seg1][0..N_SHARDS / 3])
+		let it1 = (chunks[i_seg1][0..N_SHARDS / 3])
 			.iter()
 			.enumerate()
 			.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16), c))
 			.chain(
-				(&chunks[i_seg1][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+				(chunks[i_seg1][N_SHARDS..N_SHARDS + N_SHARDS / 3])
 					.iter()
 					.enumerate()
 					.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
 			)
 			.chain(
-				(&chunks[i_seg1][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+				(chunks[i_seg1][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
 					.iter()
 					.enumerate()
 					.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
 			);
-		let it2 = (&chunks[i_seg2][0..N_SHARDS / 3])
+		let it2 = (chunks[i_seg2][0..N_SHARDS / 3])
 			.iter()
 			.enumerate()
 			.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16), c))
 			.chain(
-				(&chunks[i_seg2][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+				(chunks[i_seg2][N_SHARDS..N_SHARDS + N_SHARDS / 3])
 					.iter()
 					.enumerate()
 					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
 			)
 			.chain(
-				(&chunks[i_seg2][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+				(chunks[i_seg2][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
 					.iter()
 					.enumerate()
 					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
@@ -416,36 +416,36 @@ mod tests {
 		assert_eq!((i_seg1 as u8, segments[i_seg1].clone()), s[0]);
 		assert_eq!((i_seg2 as u8, segments[i_seg2].clone()), s[1]);
 
-		let it1 = (&chunks[i_seg1][0..N_SHARDS / 3])
+		let it1 = (chunks[i_seg1][0..N_SHARDS / 3])
 			.iter()
 			.enumerate()
 			.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16), c))
 			.chain(
-				(&chunks[i_seg1][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+				(chunks[i_seg1][N_SHARDS..N_SHARDS + N_SHARDS / 3])
 					.iter()
 					.enumerate()
 					.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
 			)
 			.chain(
-				(&chunks[i_seg1][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+				(chunks[i_seg1][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
 					.iter()
 					.enumerate()
 					.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
 			);
 
 		// unaligned a batch of chunks
-		let it3 = (&chunks[i_seg2][0 + 1..N_SHARDS / 3 + 1])
+		let it3 = (chunks[i_seg2][1..N_SHARDS / 3 + 1])
 			.iter()
 			.enumerate()
 			.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + 1), c))
 			.chain(
-				(&chunks[i_seg2][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+				(chunks[i_seg2][N_SHARDS..N_SHARDS + N_SHARDS / 3])
 					.iter()
 					.enumerate()
 					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
 			)
 			.chain(
-				(&chunks[i_seg2][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+				(chunks[i_seg2][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
 					.iter()
 					.enumerate()
 					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),

--- a/src/subshard.rs
+++ b/src/subshard.rs
@@ -419,5 +419,44 @@ mod tests {
 		assert_eq!(i, 1); // all chunk ix are aligned so can be processed at once.
 		assert_eq!((i_seg1 as u8, segments[i_seg1].clone()), s[0]);
 		assert_eq!((i_seg2 as u8, segments[i_seg2].clone()), s[1]);
+
+		let it1 = (&chunks[i_seg1][0..N_SHARDS / 3])
+			.iter()
+			.enumerate()
+			.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16), c))
+			.chain(
+				(&chunks[i_seg1][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+					.iter()
+					.enumerate()
+					.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
+			)
+			.chain(
+				(&chunks[i_seg1][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+					.iter()
+					.enumerate()
+					.map(|(i, c)| (i_seg1 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
+			);
+
+		// unaligned a batch of chunks
+		let it3 = (&chunks[i_seg2][0 + 1..N_SHARDS / 3 + 1])
+			.iter()
+			.enumerate()
+			.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + 1), c))
+			.chain(
+				(&chunks[i_seg2][N_SHARDS..N_SHARDS + N_SHARDS / 3])
+					.iter()
+					.enumerate()
+					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16), c)),
+			)
+			.chain(
+				(&chunks[i_seg2][N_SHARDS * 2..N_SHARDS * 2 + N_SHARDS / 3])
+					.iter()
+					.enumerate()
+					.map(|(i, c)| (i_seg2 as u8, ChunkIndex(i as u16 + N_SHARDS as u16 * 2), c)),
+			);
+		let (s, i) = decoder.reconstruct(&mut it1.chain(it3)).unwrap();
+		assert_eq!(i, 2); // not all chunk ix are aligned
+		assert_eq!((i_seg1 as u8, segments[i_seg1].clone()), s[0]);
+		assert_eq!((i_seg2 as u8, segments[i_seg2].clone()), s[1]);
 	}
 }


### PR DESCRIPTION
code for handling subshard of segments.
Note that this run on 3 * 64 shards (for 16 subshards) as it is the smallest aligned size for 12byte subshards so there is no need to run on bigger shards. (can also run on 64 or 2 * 64 depending on inputs).